### PR TITLE
Attempt to use cookies for all supported browsers

### DIFF
--- a/aula_download_albums_with_tags.py
+++ b/aula_download_albums_with_tags.py
@@ -130,6 +130,27 @@ def printArguments(cutoffDate, tagsToFind, outputDirectory):
     console.print(f"  outputDirectory: {outputDirectory}", style=paramStyle)
     console.print()
 
+def tryAppendAulaCookies(aulaCookies, browserName, cookieCallback):
+    try:
+        cookies = cookieCallback()
+        aulaCookies.append(cookies)
+        console.print(f"{browserName} cookies: [green]found[/]")
+    except browser_cookie3.BrowserCookieError as error:
+        console.print(f"{browserName} cookies: [yellow]not found[/]")
+
+def getAulaCookies():
+    aulaCookies = []
+    tryAppendAulaCookies(aulaCookies, 'Chrome', lambda: browser_cookie3.chrome(domain_name='aula.dk'))
+    tryAppendAulaCookies(aulaCookies, 'Chromium', lambda: browser_cookie3.chromium(domain_name='aula.dk'))
+    tryAppendAulaCookies(aulaCookies, 'Opera', lambda: browser_cookie3.opera(domain_name='aula.dk'))
+    tryAppendAulaCookies(aulaCookies, 'Opera GX', lambda: browser_cookie3.opera_gx(domain_name='aula.dk'))
+    tryAppendAulaCookies(aulaCookies, 'Brave', lambda: browser_cookie3.brave(domain_name='aula.dk'))
+    tryAppendAulaCookies(aulaCookies, 'Edge', lambda: browser_cookie3.edge(domain_name='aula.dk'))
+    tryAppendAulaCookies(aulaCookies, 'Vivaldi', lambda: browser_cookie3.vivaldi(domain_name='aula.dk'))
+    tryAppendAulaCookies(aulaCookies, 'Firefox', lambda: browser_cookie3.firefox(domain_name='aula.dk'))
+    tryAppendAulaCookies(aulaCookies, 'Safari', lambda: browser_cookie3.safari(domain_name='aula.dk'))
+    return aulaCookies
+
 console = Console()
 
 # Parse arguments
@@ -145,7 +166,7 @@ outputDirectory = args.outputFolder
 printArguments(cutoffDate, tagsToFind, outputDirectory)
 
 # Init Aula client
-aulaCookies = browser_cookie3.firefox(domain_name='aula.dk')
+aulaCookies = getAulaCookies()
 client = AulaClient(aulaCookies)
 
 try:

--- a/aulaclient.py
+++ b/aulaclient.py
@@ -8,14 +8,19 @@ class AulaClient:
 
     def __init__(self, cookies):
         self.session = requests.Session()
-        self.session.cookies = cookies
+        self.allCookies = cookies
 
     def getProfiles(self):
         params = {
             'method': 'profiles.getProfilesByLogin'
         }
 
-        response_profile = self.__sendRequest(params)
+        for cookies in self.allCookies:
+            self.session.cookies = cookies
+            response_profile = self.__sendRequest(params)
+            if response_profile['status']['code'] != 448:
+                break
+
         if response_profile['status']['code'] == 448:
             raise Exception("Cannot request profile, could be due to expired or missing cookies; try to log in.")
 


### PR DESCRIPTION
Look for aula.dk cookies in all browsers supported by browser_cookie3, and try them one by one when requesting profiles. Keep the first valid one.